### PR TITLE
Add ability to add prefix to the image name right from the environment

### DIFF
--- a/applications/postgres/versions/10.21/version_test.go
+++ b/applications/postgres/versions/10.21/version_test.go
@@ -8,13 +8,14 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/teran/go-docker-testsuite/applications/postgres/versions"
+	"github.com/teran/go-docker-testsuite/images"
 )
 
-const image = "postgres:10.21"
+const image = "index.docker.io/library/postgres:10.21"
 
 func TestScyllaDBVersion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
 
-	suite.Run(t, versions.New(ctx, image))
+	suite.Run(t, versions.New(ctx, images.ImageName(image)))
 }

--- a/applications/postgres/versions/11.16/version_test.go
+++ b/applications/postgres/versions/11.16/version_test.go
@@ -8,13 +8,14 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/teran/go-docker-testsuite/applications/postgres/versions"
+	"github.com/teran/go-docker-testsuite/images"
 )
 
-const image = "postgres:11.16"
+const image = "index.docker.io/library/postgres:11.16"
 
 func TestScyllaDBVersion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
 
-	suite.Run(t, versions.New(ctx, image))
+	suite.Run(t, versions.New(ctx, images.ImageName(image)))
 }

--- a/applications/postgres/versions/12.11/version_test.go
+++ b/applications/postgres/versions/12.11/version_test.go
@@ -8,13 +8,14 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/teran/go-docker-testsuite/applications/postgres/versions"
+	"github.com/teran/go-docker-testsuite/images"
 )
 
-const image = "postgres:12.11"
+const image = "index.docker.io/library/postgres:12.11"
 
 func TestScyllaDBVersion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
 
-	suite.Run(t, versions.New(ctx, image))
+	suite.Run(t, versions.New(ctx, images.ImageName(image)))
 }

--- a/applications/postgres/versions/13.7/version_test.go
+++ b/applications/postgres/versions/13.7/version_test.go
@@ -8,13 +8,14 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/teran/go-docker-testsuite/applications/postgres/versions"
+	"github.com/teran/go-docker-testsuite/images"
 )
 
-const image = "postgres:13.7"
+const image = "index.docker.io/library/postgres:13.7"
 
 func TestScyllaDBVersion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
 
-	suite.Run(t, versions.New(ctx, image))
+	suite.Run(t, versions.New(ctx, images.ImageName(image)))
 }

--- a/applications/postgres/versions/14.3/version_test.go
+++ b/applications/postgres/versions/14.3/version_test.go
@@ -8,13 +8,14 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/teran/go-docker-testsuite/applications/postgres/versions"
+	"github.com/teran/go-docker-testsuite/images"
 )
 
-const image = "postgres:14.3"
+const image = "index.docker.io/library/postgres:14.3"
 
 func TestScyllaDBVersion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
 
-	suite.Run(t, versions.New(ctx, image))
+	suite.Run(t, versions.New(ctx, images.ImageName(image)))
 }

--- a/applications/postgres/versions/15.7/version_test.go
+++ b/applications/postgres/versions/15.7/version_test.go
@@ -8,13 +8,14 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/teran/go-docker-testsuite/applications/postgres/versions"
+	"github.com/teran/go-docker-testsuite/images"
 )
 
-const image = "postgres:15.7"
+const image = "index.docker.io/library/postgres:15.7"
 
 func TestScyllaDBVersion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
 
-	suite.Run(t, versions.New(ctx, image))
+	suite.Run(t, versions.New(ctx, images.ImageName(image)))
 }

--- a/applications/postgres/versions/16.3/version_test.go
+++ b/applications/postgres/versions/16.3/version_test.go
@@ -8,13 +8,14 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/teran/go-docker-testsuite/applications/postgres/versions"
+	"github.com/teran/go-docker-testsuite/images"
 )
 
-const image = "postgres:16.3"
+const image = "index.docker.io/library/postgres:16.3"
 
 func TestScyllaDBVersion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
 
-	suite.Run(t, versions.New(ctx, image))
+	suite.Run(t, versions.New(ctx, images.ImageName(image)))
 }

--- a/applications/redis/versions/6.2.14/version_test.go
+++ b/applications/redis/versions/6.2.14/version_test.go
@@ -7,13 +7,14 @@ import (
 
 	"github.com/stretchr/testify/suite"
 	"github.com/teran/go-docker-testsuite/applications/redis/versions"
+	"github.com/teran/go-docker-testsuite/images"
 )
 
-const image = "redis:6.2.14"
+const image = "index.docker.io/library/redis:6.2.14"
 
 func TestScyllaDBVersion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	suite.Run(t, versions.New(ctx, image))
+	suite.Run(t, versions.New(ctx, images.ImageName(image)))
 }

--- a/applications/redis/versions/7.0.15/version_test.go
+++ b/applications/redis/versions/7.0.15/version_test.go
@@ -7,13 +7,14 @@ import (
 
 	"github.com/stretchr/testify/suite"
 	"github.com/teran/go-docker-testsuite/applications/redis/versions"
+	"github.com/teran/go-docker-testsuite/images"
 )
 
-const image = "redis:7.0.15"
+const image = "index.docker.io/library/redis:7.0.15"
 
 func TestScyllaDBVersion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	suite.Run(t, versions.New(ctx, image))
+	suite.Run(t, versions.New(ctx, images.ImageName(image)))
 }

--- a/applications/redis/versions/7.2.5/version_test.go
+++ b/applications/redis/versions/7.2.5/version_test.go
@@ -7,13 +7,14 @@ import (
 
 	"github.com/stretchr/testify/suite"
 	"github.com/teran/go-docker-testsuite/applications/redis/versions"
+	"github.com/teran/go-docker-testsuite/images"
 )
 
-const image = "redis:7.2.5"
+const image = "index.docker.io/library/redis:7.2.5"
 
 func TestScyllaDBVersion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	suite.Run(t, versions.New(ctx, image))
+	suite.Run(t, versions.New(ctx, images.ImageName(image)))
 }

--- a/applications/scylladb/versions/4.4.8/version_test.go
+++ b/applications/scylladb/versions/4.4.8/version_test.go
@@ -7,13 +7,14 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/teran/go-docker-testsuite/applications/scylladb/versions"
+	"github.com/teran/go-docker-testsuite/images"
 )
 
-const image = "scylladb/scylla:4.4.8"
+const image = "index.docker.io/scylladb/scylla:4.4.8"
 
 func TestScyllaDBVersion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), versions.ScyllaDBTestDefaultTimeout)
 	defer cancel()
 
-	suite.Run(t, versions.New(ctx, image))
+	suite.Run(t, versions.New(ctx, images.ImageName(image)))
 }

--- a/applications/scylladb/versions/4.5.6/version_test.go
+++ b/applications/scylladb/versions/4.5.6/version_test.go
@@ -7,13 +7,14 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/teran/go-docker-testsuite/applications/scylladb/versions"
+	"github.com/teran/go-docker-testsuite/images"
 )
 
-const image = "scylladb/scylla:4.5.6"
+const image = "index.docker.io/scylladb/scylla:4.5.6"
 
 func TestScyllaDBVersion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), versions.ScyllaDBTestDefaultTimeout)
 	defer cancel()
 
-	suite.Run(t, versions.New(ctx, image))
+	suite.Run(t, versions.New(ctx, images.ImageName(image)))
 }

--- a/applications/scylladb/versions/4.6.3/version_test.go
+++ b/applications/scylladb/versions/4.6.3/version_test.go
@@ -7,13 +7,14 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/teran/go-docker-testsuite/applications/scylladb/versions"
+	"github.com/teran/go-docker-testsuite/images"
 )
 
-const image = "scylladb/scylla:4.6.3"
+const image = "index.docker.io/scylladb/scylla:4.6.3"
 
 func TestScyllaDBVersion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), versions.ScyllaDBTestDefaultTimeout)
 	defer cancel()
 
-	suite.Run(t, versions.New(ctx, image))
+	suite.Run(t, versions.New(ctx, images.ImageName(image)))
 }

--- a/applications/scylladb/versions/5.0.12/version_test.go
+++ b/applications/scylladb/versions/5.0.12/version_test.go
@@ -7,13 +7,14 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/teran/go-docker-testsuite/applications/scylladb/versions"
+	"github.com/teran/go-docker-testsuite/images"
 )
 
-const image = "scylladb/scylla:5.0.12"
+const image = "index.docker.io/scylladb/scylla:5.0.12"
 
 func TestScyllaDBVersion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), versions.ScyllaDBTestDefaultTimeout)
 	defer cancel()
 
-	suite.Run(t, versions.New(ctx, image))
+	suite.Run(t, versions.New(ctx, images.ImageName(image)))
 }

--- a/applications/scylladb/versions/5.1.9/version_test.go
+++ b/applications/scylladb/versions/5.1.9/version_test.go
@@ -7,13 +7,14 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/teran/go-docker-testsuite/applications/scylladb/versions"
+	"github.com/teran/go-docker-testsuite/images"
 )
 
-const image = "scylladb/scylla:5.1.9"
+const image = "index.docker.io/scylladb/scylla:5.1.9"
 
 func TestScyllaDBVersion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), versions.ScyllaDBTestDefaultTimeout)
 	defer cancel()
 
-	suite.Run(t, versions.New(ctx, image))
+	suite.Run(t, versions.New(ctx, images.ImageName(image)))
 }

--- a/applications/scylladb/versions/5.2.18/version_test.go
+++ b/applications/scylladb/versions/5.2.18/version_test.go
@@ -7,13 +7,14 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/teran/go-docker-testsuite/applications/scylladb/versions"
+	"github.com/teran/go-docker-testsuite/images"
 )
 
-const image = "scylladb/scylla:5.2.18"
+const image = "index.docker.io/scylladb/scylla:5.2.18"
 
 func TestScyllaDBVersion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), versions.ScyllaDBTestDefaultTimeout)
 	defer cancel()
 
-	suite.Run(t, versions.New(ctx, image))
+	suite.Run(t, versions.New(ctx, images.ImageName(image)))
 }

--- a/applications/scylladb/versions/5.4.6/version_test.go
+++ b/applications/scylladb/versions/5.4.6/version_test.go
@@ -7,13 +7,14 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/teran/go-docker-testsuite/applications/scylladb/versions"
+	"github.com/teran/go-docker-testsuite/images"
 )
 
-const image = "scylladb/scylla:5.4.6"
+const image = "index.docker.io/scylladb/scylla:5.4.6"
 
 func TestScyllaDBVersion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), versions.ScyllaDBTestDefaultTimeout)
 	defer cancel()
 
-	suite.Run(t, versions.New(ctx, image))
+	suite.Run(t, versions.New(ctx, images.ImageName(image)))
 }

--- a/images/images.go
+++ b/images/images.go
@@ -1,15 +1,33 @@
 package images
 
+import (
+	"os"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
 const (
 	// EchoServer image
 	EchoServer = "ghcr.io/teran/echo-grpc-server:latest"
 
 	// Minio image tag
-	Minio = "minio/minio:RELEASE.2024-05-10T01-41-38Z"
+	Minio = "index.docker.io/minio/minio:RELEASE.2024-05-10T01-41-38Z"
 
 	// Postgres image tag
-	Postgres = "postgres:16.3"
+	Postgres = "index.docker.io/library/postgres:16.3"
 
 	// ScyllaDB image tag
-	ScyllaDB = "scylladb/scylla:5.4.6"
+	ScyllaDB = "index.docker.io/scylladb/scylla:5.4.6"
 )
+
+func ImageName(image string) string {
+	prefix := os.Getenv("IMAGE_PREFIX")
+	if prefix != "" {
+		image = strings.TrimRight(prefix, "/") + "/" + strings.TrimLeft(image, "/")
+	}
+
+	log.Tracef("image name to pull: %s", image)
+
+	return image
+}

--- a/images/images_test.go
+++ b/images/images_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package images
 
 import (

--- a/images/images_test.go
+++ b/images/images_test.go
@@ -1,0 +1,25 @@
+package images
+
+import (
+	"os"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	log.SetLevel(log.TraceLevel)
+}
+
+func TestImageName(t *testing.T) {
+	r := require.New(t)
+
+	os.Unsetenv("IMAGE_PREFIX")
+	v := ImageName("testdata")
+	r.Equal("testdata", v)
+
+	os.Setenv("IMAGE_PREFIX", "some-proxy.example.com")
+	v = ImageName("testdata")
+	r.Equal("some-proxy.example.com/testdata", v)
+}


### PR DESCRIPTION
In some cases like for using proxies it's handy to have an option to somehow override image name.
So here's a way: `IMAGE_PREFIX` environment variable will be path-joined right before the image name if defined.

Side-effect: now it's preferable to specify image names as a full-path URL and since image names are something not always a deterministic there's no way to verify them (at least for now).