### PR TITLE
feat(applications): add RabbitMQ service wrapper and versions tests

### DIFF
--- a/applications/rabbitmq/example_test.go
+++ b/applications/rabbitmq/example_test.go
@@ -1,0 +1,75 @@
+package rabbitmq_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+
+	"github.com/teran/go-docker-testsuite/applications/rabbitmq"
+)
+
+// This example demonstrates starting a RabbitMQ container, producing a message
+// and consuming it back using the AMQP 0-9-1 protocol.
+func Example() {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	app, err := rabbitmq.New(ctx)
+	if err != nil {
+		fmt.Printf("error: %v (is Docker running?)\n", err)
+		return
+	}
+	defer func() { _ = app.Close(ctx) }()
+
+	amqpURL, err := app.GetAMQPURL(ctx)
+	if err != nil {
+		fmt.Printf("error getting AMQP URL: %v\n", err)
+		return
+	}
+	fmt.Println("rabbitmq amqp:", amqpURL)
+
+	conn, err := amqp.Dial(amqpURL)
+	if err != nil {
+		fmt.Printf("error connecting: %v\n", err)
+		return
+	}
+	defer func() { _ = conn.Close() }()
+
+	ch, err := conn.Channel()
+	if err != nil {
+		fmt.Printf("error creating channel: %v\n", err)
+		return
+	}
+	defer func() { _ = ch.Close() }()
+
+	q, err := ch.QueueDeclare("greetings", false, false, false, false, nil)
+	if err != nil {
+		fmt.Printf("error declaring queue: %v\n", err)
+		return
+	}
+
+	err = ch.PublishWithContext(ctx, "", q.Name, false, false, amqp.Publishing{
+		ContentType: "text/plain",
+		Body:        []byte("hello rabbitmq"),
+	})
+	if err != nil {
+		fmt.Printf("error publishing: %v\n", err)
+		return
+	}
+	fmt.Println("message produced")
+
+	msgs, err := ch.ConsumeWithContext(ctx, q.Name, "", true, false, false, false, nil)
+	if err != nil {
+		fmt.Printf("error consuming: %v\n", err)
+		return
+	}
+
+	select {
+	case msg := <-msgs:
+		fmt.Printf("message received: %s\n", string(msg.Body))
+	case <-time.After(5 * time.Second):
+		fmt.Println("timeout waiting for message")
+	}
+}

--- a/applications/rabbitmq/rabbitmq.go
+++ b/applications/rabbitmq/rabbitmq.go
@@ -1,0 +1,185 @@
+package rabbitmq
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	docker "github.com/teran/go-docker-testsuite"
+	"github.com/teran/go-docker-testsuite/images"
+)
+
+const (
+	amqpPort       = 5672
+	managementPort = 15672
+
+	defaultUser     = "guest"
+	defaultPassword = "guest"
+)
+
+type RabbitMQ interface {
+	Close(ctx context.Context) error
+
+	GetAMQPURL(ctx context.Context) (string, error)
+	GetManagementURL(ctx context.Context) (string, error)
+
+	CreateVHost(ctx context.Context, name string) error
+	CreateUser(ctx context.Context, username, password string) error
+	SetPermissions(ctx context.Context, vhost, username, configure, write, read string) error
+}
+
+type rabbitmq struct {
+	c docker.Container
+}
+
+func New(ctx context.Context) (RabbitMQ, error) {
+	return NewWithImage(ctx, images.RabbitMQ)
+}
+
+func NewWithImage(ctx context.Context, image string) (RabbitMQ, error) {
+	c, err := docker.NewContainer(
+		"rabbitmq",
+		image,
+		nil,
+		docker.NewEnvironment().
+			StringVar("RABBITMQ_DEFAULT_USER", defaultUser).
+			StringVar("RABBITMQ_DEFAULT_PASS", defaultPassword),
+		docker.NewPortBindings().
+			PortDNAT(docker.ProtoTCP, amqpPort).
+			PortDNAT(docker.ProtoTCP, managementPort),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := c.Run(ctx); err != nil {
+		return nil, err
+	}
+
+	if err := c.AwaitOutput(ctx, docker.NewSubstringMatcher("Server startup complete")); err != nil {
+		return nil, err
+	}
+
+	time.Sleep(1 * time.Second)
+
+	return &rabbitmq{
+		c: c,
+	}, nil
+}
+
+func (r *rabbitmq) Close(ctx context.Context) error {
+	return r.c.Close(ctx)
+}
+
+func (r *rabbitmq) GetAMQPURL(ctx context.Context) (string, error) {
+	hp, err := r.c.URL(docker.ProtoTCP, amqpPort)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("amqp://guest:guest@%s/", hp.String()), nil
+}
+
+func (r *rabbitmq) GetManagementURL(ctx context.Context) (string, error) {
+	hp, err := r.c.URL(docker.ProtoTCP, managementPort)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("http://%s", hp.String()), nil
+}
+
+func (r *rabbitmq) CreateVHost(ctx context.Context, name string) error {
+	mgmtURL, err := r.GetManagementURL(ctx)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut,
+		fmt.Sprintf("%s/api/vhosts/%s", mgmtURL, url.PathEscape(name)), nil)
+	if err != nil {
+		return err
+	}
+	req.SetBasicAuth(defaultUser, defaultPassword)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unexpected response creating vhost %q: %d %s", name, resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+func (r *rabbitmq) CreateUser(ctx context.Context, username, password string) error {
+	mgmtURL, err := r.GetManagementURL(ctx)
+	if err != nil {
+		return err
+	}
+
+	body := fmt.Sprintf(`{"password":"%s","tags":"administrator"}`, password)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut,
+		fmt.Sprintf("%s/api/users/%s", mgmtURL, username),
+		strings.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.SetBasicAuth(defaultUser, defaultPassword)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unexpected response creating user %q: %d %s", username, resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+func (r *rabbitmq) SetPermissions(ctx context.Context, vhost, username, configure, write, read string) error {
+	mgmtURL, err := r.GetManagementURL(ctx)
+	if err != nil {
+		return err
+	}
+
+	body := fmt.Sprintf(
+		`{"configure":"%s","write":"%s","read":"%s"}`,
+		configure, write, read,
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut,
+		fmt.Sprintf("%s/api/permissions/%s/%s", mgmtURL, url.PathEscape(vhost), username),
+		strings.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.SetBasicAuth(defaultUser, defaultPassword)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unexpected response setting permissions for %q on %q: %d %s",
+			username, vhost, resp.StatusCode, string(body))
+	}
+
+	return nil
+}

--- a/applications/rabbitmq/rabbitmq_test.go
+++ b/applications/rabbitmq/rabbitmq_test.go
@@ -1,0 +1,115 @@
+package rabbitmq
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/suite"
+)
+
+func init() {
+	log.SetLevel(log.TraceLevel)
+}
+
+type rabbitMQAppTestSuite struct {
+	suite.Suite
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	app    RabbitMQ
+}
+
+func (s *rabbitMQAppTestSuite) SetupTest() {
+	s.ctx, s.cancel = context.WithTimeout(s.T().Context(), 2*time.Minute)
+
+	var err error
+	s.app, err = New(s.ctx)
+	s.Require().NoError(err)
+}
+
+func (s *rabbitMQAppTestSuite) TearDownTest() {
+	s.Require().NoError(s.app.Close(s.T().Context()))
+}
+
+func TestRabbitMQAppTestSuite(t *testing.T) {
+	suite.Run(t, &rabbitMQAppTestSuite{})
+}
+
+func (s *rabbitMQAppTestSuite) TestURLs() {
+	amqpURL, err := s.app.GetAMQPURL(s.ctx)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(amqpURL)
+	s.T().Logf("AMQP URL: %s", amqpURL)
+
+	mgmtURL, err := s.app.GetManagementURL(s.ctx)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(mgmtURL)
+	s.T().Logf("Management URL: %s", mgmtURL)
+}
+
+func (s *rabbitMQAppTestSuite) TestPublishConsume() {
+	amqpURL, err := s.app.GetAMQPURL(s.ctx)
+	s.Require().NoError(err)
+
+	conn, err := amqp.Dial(amqpURL)
+	s.Require().NoError(err)
+	defer func() { _ = conn.Close() }()
+
+	ch, err := conn.Channel()
+	s.Require().NoError(err)
+	defer func() { _ = ch.Close() }()
+
+	q, err := ch.QueueDeclare("test-queue", false, false, false, false, nil)
+	s.Require().NoError(err)
+
+	err = ch.PublishWithContext(s.ctx, "", q.Name, false, false, amqp.Publishing{
+		ContentType: "text/plain",
+		Body:        []byte("hello rabbitmq"),
+	})
+	s.Require().NoError(err)
+
+	msgs, err := ch.ConsumeWithContext(s.ctx, q.Name, "", true, false, false, false, nil)
+	s.Require().NoError(err)
+
+	select {
+	case msg := <-msgs:
+		s.Require().Equal("hello rabbitmq", string(msg.Body))
+	case <-time.After(5 * time.Second):
+		s.T().Fatal("timeout waiting for message")
+	}
+}
+
+func (s *rabbitMQAppTestSuite) TestVHostManagement() {
+	err := s.app.CreateVHost(s.ctx, "/test-vhost")
+	s.Require().NoError(err)
+
+	err = s.app.CreateUser(s.ctx, "testuser", "testpass")
+	s.Require().NoError(err)
+
+	err = s.app.SetPermissions(s.ctx, "/test-vhost", "testuser", ".*", ".*", ".*")
+	s.Require().NoError(err)
+
+	// Verify the new user can connect to the new vhost
+	amqpURL, err := s.app.GetAMQPURL(s.ctx)
+	s.Require().NoError(err)
+
+	// Replace default credentials and vhost with custom ones
+	connURL := fmt.Sprintf("amqp://testuser:testpass@%s/test-vhost",
+		strings.TrimPrefix(amqpURL, "amqp://guest:guest@"))
+
+	conn, err := amqp.Dial(connURL)
+	s.Require().NoError(err)
+	defer func() { _ = conn.Close() }()
+
+	ch, err := conn.Channel()
+	s.Require().NoError(err)
+	defer func() { _ = ch.Close() }()
+
+	_, err = ch.QueueDeclare("verify-queue", false, false, false, false, nil)
+	s.Require().NoError(err)
+}

--- a/applications/rabbitmq/versions/3.13/version_test.go
+++ b/applications/rabbitmq/versions/3.13/version_test.go
@@ -1,0 +1,20 @@
+package rabbitmq
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/teran/go-docker-testsuite/applications/rabbitmq/versions"
+)
+
+const image = "index.docker.io/library/rabbitmq:3.13-management"
+
+func TestRabbitMQVersion(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
+	defer cancel()
+
+	suite.Run(t, versions.New(ctx, image))
+}

--- a/applications/rabbitmq/versions/4.0/version_test.go
+++ b/applications/rabbitmq/versions/4.0/version_test.go
@@ -1,0 +1,20 @@
+package rabbitmq
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/teran/go-docker-testsuite/applications/rabbitmq/versions"
+)
+
+const image = "index.docker.io/library/rabbitmq:4.0-management"
+
+func TestRabbitMQVersion(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
+	defer cancel()
+
+	suite.Run(t, versions.New(ctx, image))
+}

--- a/applications/rabbitmq/versions/versions.go
+++ b/applications/rabbitmq/versions/versions.go
@@ -1,0 +1,100 @@
+package versions
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/teran/go-docker-testsuite/applications/rabbitmq"
+)
+
+func init() {
+	log.SetLevel(log.TraceLevel)
+}
+
+type testSuite struct {
+	suite.Suite
+
+	ctx   context.Context
+	image string
+}
+
+func New(ctx context.Context, image string) *testSuite {
+	return &testSuite{
+		ctx:   ctx,
+		image: image,
+	}
+}
+
+func (s *testSuite) TestAMQP() {
+	app, err := rabbitmq.NewWithImage(s.ctx, s.image)
+	s.Require().NoError(err)
+	defer func() {
+		err := app.Close(s.ctx)
+		s.Require().NoError(err)
+	}()
+
+	amqpURL, err := app.GetAMQPURL(s.ctx)
+	s.Require().NoError(err)
+
+	conn, err := amqp.Dial(amqpURL)
+	s.Require().NoError(err)
+	defer func() { _ = conn.Close() }()
+
+	ch, err := conn.Channel()
+	s.Require().NoError(err)
+	defer func() { _ = ch.Close() }()
+
+	q, err := ch.QueueDeclare("version-test-queue", false, false, false, false, nil)
+	s.Require().NoError(err)
+
+	err = ch.PublishWithContext(s.ctx, "", q.Name, false, false, amqp.Publishing{
+		ContentType: "text/plain",
+		Body:        []byte("version check"),
+	})
+	s.Require().NoError(err)
+
+	msgs, err := ch.ConsumeWithContext(s.ctx, q.Name, "", true, false, false, false, nil)
+	s.Require().NoError(err)
+
+	select {
+	case msg := <-msgs:
+		s.Require().Equal("version check", string(msg.Body))
+	case <-time.After(5 * time.Second):
+		s.T().Fatal("timeout waiting for message")
+	}
+}
+
+func (s *testSuite) TestManagementAPI() {
+	app, err := rabbitmq.NewWithImage(s.ctx, s.image)
+	s.Require().NoError(err)
+	defer func() {
+		err := app.Close(s.ctx)
+		s.Require().NoError(err)
+	}()
+
+	err = app.CreateVHost(s.ctx, "/version-test-vhost")
+	s.Require().NoError(err)
+
+	err = app.CreateUser(s.ctx, "version-user", "version-pass")
+	s.Require().NoError(err)
+
+	err = app.SetPermissions(s.ctx, "/version-test-vhost", "version-user", ".*", ".*", ".*")
+	s.Require().NoError(err)
+
+	// Verify by connecting with the new credentials
+	amqpURL, err := app.GetAMQPURL(s.ctx)
+	s.Require().NoError(err)
+
+	connURL := fmt.Sprintf("amqp://version-user:version-pass@%s/version-test-vhost",
+		strings.TrimPrefix(amqpURL, "amqp://guest:guest@"))
+
+	conn, err := amqp.Dial(connURL)
+	s.Require().NoError(err)
+	_ = conn.Close()
+}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/jackc/pgx/v4 v4.18.3
 	github.com/minio/minio-go/v7 v7.2.1
 	github.com/pkg/errors v0.9.1
+	github.com/rabbitmq/amqp091-go v1.12.0
 	github.com/sirupsen/logrus v1.9.4
 	github.com/stretchr/testify v1.11.1
 	github.com/teran/echo-grpc-server v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -234,6 +234,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rabbitmq/amqp091-go v1.12.0 h1:V0v14Iqfs+MwHWihJt/nGS5Ulu0vw572b2Co3mwunkI=
+github.com/rabbitmq/amqp091-go v1.12.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
 github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 h1:bsUq1dX0N8AOIL7EB/X911+m4EHsnWEHeJ0c+3TTBrg=
 github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/images/images.go
+++ b/images/images.go
@@ -18,4 +18,7 @@ const (
 
 	// ScyllaDB image tag
 	ScyllaDB = "index.docker.io/scylladb/scylla:5.4.6"
+
+	// RabbitMQ image tag
+	RabbitMQ = "index.docker.io/library/rabbitmq:4.0-management"
 )


### PR DESCRIPTION
Introduce RabbitMQ application wrapper for the docker test suite:
- Interface with GetAMQPURL, GetManagementURL, CreateVHost, CreateUser, SetPermissions, and Close methods
- Management API support via RabbitMQ HTTP API for vhost/user and permission management
- Integration tests covering publish/consume and vhost management
- Runnable Example demonstrating full lifecycle
- Version tests for RabbitMQ 4.0 and 3.13 (shared test suite)
- Default image: rabbitmq:4.0-management
- Add github.com/rabbitmq/amqp091-go dependency