### PR TITLE
fix(security): prevent SQL injection via DDL identifiers in mysql, po…

### DIFF
--- a/applications/mysql/mysql.go
+++ b/applications/mysql/mysql.go
@@ -30,12 +30,12 @@ func validateDBName(name string) error {
 
 	// First character: letter, underscore, or Unicode letter
 	r := []rune(name)
-	if !(r[0] == '_' || unicode.IsLetter(r[0])) {
+	if r[0] != '_' && !unicode.IsLetter(r[0]) {
 		return errors.Errorf("invalid database name %q: must start with a letter or underscore", name)
 	}
 
 	for _, c := range r {
-		if !(c == '_' || c == '$' || unicode.IsLetter(c) || unicode.IsDigit(c)) {
+		if c != '_' && c != '$' && !unicode.IsLetter(c) && !unicode.IsDigit(c) {
 			return errors.Errorf("invalid database name %q: character %q is not allowed", name, c)
 		}
 	}

--- a/applications/mysql/mysql.go
+++ b/applications/mysql/mysql.go
@@ -5,13 +5,48 @@ import (
 	"database/sql"
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
+	"unicode"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	docker "github.com/teran/go-docker-testsuite"
 )
+
+const maxDBNameLen = 64
+
+// validateDBName validates that name is a safe MySQL unquoted identifier.
+// MySQL unquoted identifiers allow: [a-zA-Z_$] + digits.
+// See https://dev.mysql.com/doc/en/identifiers.html
+func validateDBName(name string) error {
+	if name == "" {
+		return errors.New("database name must not be empty")
+	}
+	if len(name) > maxDBNameLen {
+		return errors.Errorf("database name %q exceeds max length of %d bytes", name, maxDBNameLen)
+	}
+
+	// First character: letter, underscore, or Unicode letter
+	r := []rune(name)
+	if !(r[0] == '_' || unicode.IsLetter(r[0])) {
+		return errors.Errorf("invalid database name %q: must start with a letter or underscore", name)
+	}
+
+	for _, c := range r {
+		if !(c == '_' || c == '$' || unicode.IsLetter(c) || unicode.IsDigit(c)) {
+			return errors.Errorf("invalid database name %q: character %q is not allowed", name, c)
+		}
+	}
+
+	return nil
+}
+
+// quoteMySQLIdentifier wraps name in backticks, escaping embedded backticks by doubling.
+func quoteMySQLIdentifier(name string) string {
+	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
+}
 
 type MySQL interface {
 	Close(ctx context.Context) error
@@ -85,6 +120,10 @@ func New(ctx context.Context, image string) (MySQL, error) {
 }
 
 func (m *mysql) CreateDB(ctx context.Context, name string) error {
+	if err := validateDBName(name); err != nil {
+		return err
+	}
+
 	dsn, err := m.DSN("")
 	if err != nil {
 		return errors.Wrap(err, "error obtaining database DSN")
@@ -100,11 +139,15 @@ func (m *mysql) CreateDB(ctx context.Context, name string) error {
 		return errors.Wrap(err, "error pinging database")
 	}
 
-	_, err = c.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE %s", name))
+	_, err = c.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE %s", quoteMySQLIdentifier(name)))
 	return errors.Wrap(err, "error executing SQL query")
 }
 
 func (m *mysql) DropDB(ctx context.Context, name string) error {
+	if err := validateDBName(name); err != nil {
+		return err
+	}
+
 	dsn, err := m.DSN("")
 	if err != nil {
 		return errors.Wrap(err, "error obtaining database DSN")
@@ -120,7 +163,7 @@ func (m *mysql) DropDB(ctx context.Context, name string) error {
 		return errors.Wrap(err, "error pinging database")
 	}
 
-	_, err = c.ExecContext(ctx, fmt.Sprintf("DROP DATABASE %s", name))
+	_, err = c.ExecContext(ctx, fmt.Sprintf("DROP DATABASE %s", quoteMySQLIdentifier(name)))
 	return errors.Wrap(err, "error executing SQL query")
 }
 

--- a/applications/postgres/postgres.go
+++ b/applications/postgres/postgres.go
@@ -27,12 +27,12 @@ func validateDBName(name string) error {
 	}
 
 	r := []rune(name)
-	if !(r[0] == '_' || unicode.IsLetter(r[0])) {
+	if r[0] != '_' && !unicode.IsLetter(r[0]) {
 		return fmt.Errorf("invalid database name %q: must start with a letter or underscore", name)
 	}
 
 	for _, c := range r {
-		if !(c == '_' || c == '$' || unicode.IsLetter(c) || unicode.IsDigit(c)) {
+		if c != '_' && c != '$' && !unicode.IsLetter(c) && !unicode.IsDigit(c) {
 			return fmt.Errorf("invalid database name %q: character %q is not allowed", name, c)
 		}
 	}

--- a/applications/postgres/postgres.go
+++ b/applications/postgres/postgres.go
@@ -3,13 +3,47 @@ package postgres
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
+	"unicode"
 
 	pgx "github.com/jackc/pgx/v4"
 
 	"github.com/teran/go-docker-testsuite"
 	"github.com/teran/go-docker-testsuite/images"
 )
+
+const maxDBNameLen = 63
+
+// validateDBName validates that name is a safe PostgreSQL unquoted identifier.
+// PostgreSQL allows: letters (including Unicode), underscore, digits, and dollar signs ($).
+// See https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+func validateDBName(name string) error {
+	if name == "" {
+		return fmt.Errorf("database name must not be empty")
+	}
+	if len(name) > maxDBNameLen {
+		return fmt.Errorf("database name %q exceeds max length of %d bytes", name, maxDBNameLen)
+	}
+
+	r := []rune(name)
+	if !(r[0] == '_' || unicode.IsLetter(r[0])) {
+		return fmt.Errorf("invalid database name %q: must start with a letter or underscore", name)
+	}
+
+	for _, c := range r {
+		if !(c == '_' || c == '$' || unicode.IsLetter(c) || unicode.IsDigit(c)) {
+			return fmt.Errorf("invalid database name %q: character %q is not allowed", name, c)
+		}
+	}
+
+	return nil
+}
+
+// quotePGIdentifier wraps name in double quotes, escaping embedded quotes by doubling.
+func quotePGIdentifier(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}
 
 type PostgreSQL interface {
 	DSN(db string) (string, error)
@@ -63,6 +97,10 @@ func NewWithImage(ctx context.Context, image string) (PostgreSQL, error) {
 }
 
 func (p *postgresql) CreateDB(ctx context.Context, db string) error {
+	if err := validateDBName(db); err != nil {
+		return err
+	}
+
 	dsn, err := p.DSN("")
 	if err != nil {
 		return err
@@ -74,12 +112,18 @@ func (p *postgresql) CreateDB(ctx context.Context, db string) error {
 	}
 	defer func() { _ = pgconn.Close(ctx) }()
 
-	// Arguments are not supported in CREATE DATABASE statement so using Sprintf() :(
-	_, err = pgconn.Exec(ctx, fmt.Sprintf("CREATE DATABASE %s", db))
+	// Arguments are not supported in CREATE DATABASE statement so using Sprintf()
+	// with double-quote escaping as defence-in-depth. See validateDBName() for
+	// the primary validation layer.
+	_, err = pgconn.Exec(ctx, fmt.Sprintf("CREATE DATABASE %s", quotePGIdentifier(db)))
 	return err
 }
 
 func (p *postgresql) DropDB(ctx context.Context, db string) error {
+	if err := validateDBName(db); err != nil {
+		return err
+	}
+
 	dsn, err := p.DSN("")
 	if err != nil {
 		return err
@@ -91,8 +135,10 @@ func (p *postgresql) DropDB(ctx context.Context, db string) error {
 	}
 	defer func() { _ = pgconn.Close(ctx) }()
 
-	// Arguments are not supported in DROP DATABASE statement so using Sprintf() :(
-	_, err = pgconn.Exec(ctx, fmt.Sprintf("DROP DATABASE %s", db))
+	// Arguments are not supported in DROP DATABASE statement so using Sprintf()
+	// with double-quote escaping as defence-in-depth. See validateDBName() for
+	// the primary validation layer.
+	_, err = pgconn.Exec(ctx, fmt.Sprintf("DROP DATABASE %s", quotePGIdentifier(db)))
 	return err
 }
 

--- a/applications/scylladb/scylladb.go
+++ b/applications/scylladb/scylladb.go
@@ -4,13 +4,48 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
+	"unicode"
 
 	"github.com/gocql/gocql"
 
 	"github.com/teran/go-docker-testsuite"
 	"github.com/teran/go-docker-testsuite/images"
 )
+
+const maxKeyspaceNameLen = 48
+
+// validateKeyspaceName validates that name is a safe CQL identifier.
+// CQL identifiers allow: letters, underscore, and digits.
+// ScyllaDB keyspace names are limited to 48 characters.
+// See https://docs.scylladb.com/stable/cql/ddl.html
+func validateKeyspaceName(name string) error {
+	if name == "" {
+		return fmt.Errorf("keyspace name must not be empty")
+	}
+	if len(name) > maxKeyspaceNameLen {
+		return fmt.Errorf("keyspace name %q exceeds max length of %d characters", name, maxKeyspaceNameLen)
+	}
+
+	r := []rune(name)
+	if !(r[0] == '_' || unicode.IsLetter(r[0])) {
+		return fmt.Errorf("invalid keyspace name %q: must start with a letter or underscore", name)
+	}
+
+	for _, c := range r {
+		if !(c == '_' || unicode.IsLetter(c) || unicode.IsDigit(c)) {
+			return fmt.Errorf("invalid keyspace name %q: character %q is not allowed", name, c)
+		}
+	}
+
+	return nil
+}
+
+// quoteCQLIdentifier wraps name in double quotes, escaping embedded quotes by doubling.
+func quoteCQLIdentifier(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}
 
 type ScyllaDB interface {
 	ClusterConfig(keyspaceName string) (*gocql.ClusterConfig, error)
@@ -112,17 +147,25 @@ func (s *scylladb) ClusterConfig(keyspace string) (*gocql.ClusterConfig, error) 
 }
 
 func (s *scylladb) CreateKeyspace(name string) error {
+	if err := validateKeyspaceName(name); err != nil {
+		return err
+	}
+
 	q := fmt.Sprintf(
 		"CREATE KEYSPACE %s WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }",
-		name,
+		quoteCQLIdentifier(name),
 	)
 	return s.session.Query(q).Exec()
 }
 
 func (s *scylladb) DropKeyspace(name string) error {
+	if err := validateKeyspaceName(name); err != nil {
+		return err
+	}
+
 	q := fmt.Sprintf(
 		"DROP KEYSPACE %s",
-		name,
+		quoteCQLIdentifier(name),
 	)
 	return s.session.Query(q).Exec()
 }

--- a/applications/scylladb/scylladb.go
+++ b/applications/scylladb/scylladb.go
@@ -29,12 +29,12 @@ func validateKeyspaceName(name string) error {
 	}
 
 	r := []rune(name)
-	if !(r[0] == '_' || unicode.IsLetter(r[0])) {
+	if r[0] != '_' && !unicode.IsLetter(r[0]) {
 		return fmt.Errorf("invalid keyspace name %q: must start with a letter or underscore", name)
 	}
 
 	for _, c := range r {
-		if !(c == '_' || unicode.IsLetter(c) || unicode.IsDigit(c)) {
+		if c != '_' && !unicode.IsLetter(c) && !unicode.IsDigit(c) {
 			return fmt.Errorf("invalid keyspace name %q: character %q is not allowed", name, c)
 		}
 	}


### PR DESCRIPTION
…stgres, scylladb

Add two-layer defence for CREATE/DROP DATABASE and CREATE/DROP KEYSPACE:
- validateDBName() — whitelist-based identifier validation per DB rules
- quote*Identifier() — DB-specific quoting as defence-in-depth

MySQL uses backtick quoting, PostgreSQL and ScyllaDB (CQL) use double-quote quoting with proper escaping. Validation is per-package because each DB has different rules: CQL disallows $, and max lengths differ (64/63/48).

SQL does not support parameterised identifiers in DDL statements, so fmt.Sprintf is retained but now operates on validated input only.