### PR TITLE
Fix pullImage: replace spurious ImageLoad call with draining the pull…

### DIFF
--- a/container.go
+++ b/container.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"bufio"
 	"context"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -288,15 +289,16 @@ func (c *container) pullImage(ctx context.Context) error {
 	}
 
 	if isLatest || err == errImageIsNotPulled {
-		image, err := c.cli.ImagePull(ctx, c.image, image.PullOptions{})
+		rc, err := c.cli.ImagePull(ctx, c.image, image.PullOptions{})
 		if err != nil {
 			return errors.Wrap(err, "error pulling image")
 		}
-		defer func() { _ = image.Close() }()
+		defer func() { _ = rc.Close() }()
 
-		_, err = c.cli.ImageLoad(ctx, image, client.ImageLoadWithQuiet(false))
+		// Drain the pull response to wait for the pull to complete.
+		_, err = io.Copy(io.Discard, rc)
 		if err != nil {
-			return errors.Wrap(err, "error loading image")
+			return errors.Wrap(err, "error waiting for image pull to complete")
 		}
 	}
 


### PR DESCRIPTION
… stream

ImageLoad expects a tar archive, but ImagePull returns a JSON progress stream. Passing it to ImageLoad is both incorrect and potentially error-prone. Replace with io.Copy(io.Discard, rc) to drain the response and wait for the pull to complete.