### PR TITLE
Fix race condition in random.String: use math/rand/v2 top-level funct…

### DIFF
--- a/internal/random/random.go
+++ b/internal/random/random.go
@@ -1,11 +1,6 @@
 package random
 
-import (
-	"math/rand"
-	"time"
-)
-
-var rng = rand.New(rand.NewSource(time.Now().UnixNano()))
+import "math/rand/v2"
 
 var (
 	Numeric      = []rune("0123456789")
@@ -16,7 +11,7 @@ var (
 func String(set []rune, l uint) string {
 	s := make([]rune, l)
 	for i := range s {
-		s[i] = set[rng.Intn(len(set))]
+		s[i] = set[rand.IntN(len(set))]
 	}
 	return string(s)
 }


### PR DESCRIPTION
…ions

The package-level *rand.Rand instance was not safe for concurrent use, causing a data race under parallel test execution. Switch to math/rand/v2 top-level rand.IntN(), which is thread-safe (via a locked global source), and remove the custom rng variable.