### PR TITLE
Prevent container leaks on initialization failure in all application …

### DIFF
--- a/applications/k3s/k3s.go
+++ b/applications/k3s/k3s.go
@@ -93,7 +93,9 @@ func NewWithImage(ctx context.Context, image string) (K3s, error) {
 	started := false
 	defer func() {
 		if !started {
-			_ = c.Close(ctx)
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			_ = c.Close(cleanupCtx)
 		}
 	}()
 

--- a/applications/k3s/k3s.go
+++ b/applications/k3s/k3s.go
@@ -90,6 +90,13 @@ func NewWithImage(ctx context.Context, image string) (K3s, error) {
 		return nil, errors.Wrap(err, "error creating k3s container")
 	}
 
+	started := false
+	defer func() {
+		if !started {
+			_ = c.Close(ctx)
+		}
+	}()
+
 	if err := c.Run(ctx); err != nil {
 		return nil, errors.Wrap(err, "error running k3s container")
 	}
@@ -122,6 +129,7 @@ func NewWithImage(ctx context.Context, image string) (K3s, error) {
 		return nil, errors.Wrap(err, "error rewriting kubeconfig")
 	}
 
+	started = true
 	return k, nil
 }
 

--- a/applications/kafka/kafka.go
+++ b/applications/kafka/kafka.go
@@ -94,6 +94,13 @@ func NewWithImage(ctx context.Context, image string) (Kafka, error) {
 		return nil, err
 	}
 
+	started := false
+	defer func() {
+		if !started {
+			_ = c.Close(ctx)
+		}
+	}()
+
 	err = c.Run(ctx)
 	if err != nil {
 		return nil, err
@@ -104,6 +111,7 @@ func NewWithImage(ctx context.Context, image string) (Kafka, error) {
 		return nil, err
 	}
 
+	started = true
 	return &kafka{
 		c: c,
 	}, nil

--- a/applications/kafka/kafka.go
+++ b/applications/kafka/kafka.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/teran/go-docker-testsuite"
 	"github.com/teran/go-docker-testsuite/images"
@@ -97,7 +98,9 @@ func NewWithImage(ctx context.Context, image string) (Kafka, error) {
 	started := false
 	defer func() {
 		if !started {
-			_ = c.Close(ctx)
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			_ = c.Close(cleanupCtx)
 		}
 	}()
 

--- a/applications/memcache/memcache.go
+++ b/applications/memcache/memcache.go
@@ -38,6 +38,13 @@ func NewWithImage(ctx context.Context, image string) (Memcache, error) {
 		return nil, err
 	}
 
+	started := false
+	defer func() {
+		if !started {
+			_ = c.Close(ctx)
+		}
+	}()
+
 	if err := c.Run(ctx); err != nil {
 		return nil, err
 	}
@@ -59,6 +66,7 @@ func NewWithImage(ctx context.Context, image string) (Memcache, error) {
 				continue
 			}
 
+			started = true
 			return &memcache{
 				c: c,
 			}, nil

--- a/applications/memcache/memcache.go
+++ b/applications/memcache/memcache.go
@@ -41,7 +41,9 @@ func NewWithImage(ctx context.Context, image string) (Memcache, error) {
 	started := false
 	defer func() {
 		if !started {
-			_ = c.Close(ctx)
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			_ = c.Close(cleanupCtx)
 		}
 	}()
 

--- a/applications/minio/minio.go
+++ b/applications/minio/minio.go
@@ -3,6 +3,7 @@ package minio
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/teran/go-docker-testsuite"
 	"github.com/teran/go-docker-testsuite/images"
@@ -55,7 +56,9 @@ func NewWithImage(ctx context.Context, image string) (Minio, error) {
 	started := false
 	defer func() {
 		if !started {
-			_ = c.Close(ctx)
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			_ = c.Close(cleanupCtx)
 		}
 	}()
 

--- a/applications/minio/minio.go
+++ b/applications/minio/minio.go
@@ -52,6 +52,13 @@ func NewWithImage(ctx context.Context, image string) (Minio, error) {
 		return nil, err
 	}
 
+	started := false
+	defer func() {
+		if !started {
+			_ = c.Close(ctx)
+		}
+	}()
+
 	err = c.Run(ctx)
 	if err != nil {
 		return nil, err
@@ -64,6 +71,7 @@ func NewWithImage(ctx context.Context, image string) (Minio, error) {
 		return nil, err
 	}
 
+	started = true
 	return &minio{
 		c: c,
 	}, nil

--- a/applications/mysql/mysql.go
+++ b/applications/mysql/mysql.go
@@ -83,7 +83,9 @@ func New(ctx context.Context, image string) (MySQL, error) {
 	started := false
 	defer func() {
 		if !started {
-			_ = c.Close(ctx)
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			_ = c.Close(cleanupCtx)
 		}
 	}()
 

--- a/applications/mysql/mysql.go
+++ b/applications/mysql/mysql.go
@@ -80,6 +80,13 @@ func New(ctx context.Context, image string) (MySQL, error) {
 		c: c,
 	}
 
+	started := false
+	defer func() {
+		if !started {
+			_ = c.Close(ctx)
+		}
+	}()
+
 	if err := c.Run(ctx); err != nil {
 		return nil, errors.Wrap(err, "error running container")
 	}
@@ -116,6 +123,7 @@ func New(ctx context.Context, image string) (MySQL, error) {
 		time.Sleep(1 * time.Second)
 	}
 
+	started = true
 	return app, nil
 }
 

--- a/applications/postgres/postgres.go
+++ b/applications/postgres/postgres.go
@@ -81,7 +81,9 @@ func NewWithImage(ctx context.Context, image string) (PostgreSQL, error) {
 	started := false
 	defer func() {
 		if !started {
-			_ = c.Close(ctx)
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			_ = c.Close(cleanupCtx)
 		}
 	}()
 

--- a/applications/postgres/postgres.go
+++ b/applications/postgres/postgres.go
@@ -78,6 +78,13 @@ func NewWithImage(ctx context.Context, image string) (PostgreSQL, error) {
 		return nil, err
 	}
 
+	started := false
+	defer func() {
+		if !started {
+			_ = c.Close(ctx)
+		}
+	}()
+
 	err = c.Run(ctx)
 	if err != nil {
 		return nil, err
@@ -91,6 +98,7 @@ func NewWithImage(ctx context.Context, image string) (PostgreSQL, error) {
 	// NB: give it some time to assign a port
 	time.Sleep(1 * time.Second)
 
+	started = true
 	return &postgresql{
 		c: c,
 	}, nil

--- a/applications/rabbitmq/rabbitmq.go
+++ b/applications/rabbitmq/rabbitmq.go
@@ -56,6 +56,13 @@ func NewWithImage(ctx context.Context, image string) (RabbitMQ, error) {
 		return nil, err
 	}
 
+	started := false
+	defer func() {
+		if !started {
+			_ = c.Close(ctx)
+		}
+	}()
+
 	if err := c.Run(ctx); err != nil {
 		return nil, err
 	}
@@ -66,6 +73,7 @@ func NewWithImage(ctx context.Context, image string) (RabbitMQ, error) {
 
 	time.Sleep(1 * time.Second)
 
+	started = true
 	return &rabbitmq{
 		c: c,
 	}, nil

--- a/applications/rabbitmq/rabbitmq.go
+++ b/applications/rabbitmq/rabbitmq.go
@@ -59,7 +59,9 @@ func NewWithImage(ctx context.Context, image string) (RabbitMQ, error) {
 	started := false
 	defer func() {
 		if !started {
-			_ = c.Close(ctx)
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			_ = c.Close(cleanupCtx)
 		}
 	}()
 

--- a/applications/redis/redis.go
+++ b/applications/redis/redis.go
@@ -31,6 +31,13 @@ func New(ctx context.Context, image string) (Redis, error) {
 		return nil, err
 	}
 
+	started := false
+	defer func() {
+		if !started {
+			_ = c.Close(ctx)
+		}
+	}()
+
 	err = c.Run(ctx)
 	if err != nil {
 		return nil, err
@@ -41,6 +48,7 @@ func New(ctx context.Context, image string) (Redis, error) {
 		return nil, err
 	}
 
+	started = true
 	return &redis{
 		c: c,
 	}, nil

--- a/applications/redis/redis.go
+++ b/applications/redis/redis.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"context"
+	"time"
 
 	"github.com/teran/go-docker-testsuite"
 )
@@ -34,7 +35,9 @@ func New(ctx context.Context, image string) (Redis, error) {
 	started := false
 	defer func() {
 		if !started {
-			_ = c.Close(ctx)
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			_ = c.Close(cleanupCtx)
 		}
 	}()
 

--- a/applications/scylladb/scylladb.go
+++ b/applications/scylladb/scylladb.go
@@ -87,7 +87,9 @@ func NewWithImage(ctx context.Context, image string) (ScyllaDB, error) {
 	started := false
 	defer func() {
 		if !started {
-			_ = c.Close(ctx)
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			_ = c.Close(cleanupCtx)
 		}
 	}()
 

--- a/applications/scylladb/scylladb.go
+++ b/applications/scylladb/scylladb.go
@@ -84,6 +84,13 @@ func NewWithImage(ctx context.Context, image string) (ScyllaDB, error) {
 		return nil, err
 	}
 
+	started := false
+	defer func() {
+		if !started {
+			_ = c.Close(ctx)
+		}
+	}()
+
 	err = c.Run(ctx)
 	if err != nil {
 		return nil, err
@@ -120,6 +127,7 @@ func NewWithImage(ctx context.Context, image string) (ScyllaDB, error) {
 
 	sd.session = session
 
+	started = true
 	return sd, nil
 }
 

--- a/applications/vault/vault.go
+++ b/applications/vault/vault.go
@@ -45,6 +45,13 @@ func New(ctx context.Context, image string) (Vault, error) {
 		return nil, err
 	}
 
+	started := false
+	defer func() {
+		if !started {
+			_ = c.Close(ctx)
+		}
+	}()
+
 	err = c.Run(ctx)
 	if err != nil {
 		return nil, err
@@ -55,6 +62,7 @@ func New(ctx context.Context, image string) (Vault, error) {
 		return nil, err
 	}
 
+	started = true
 	return &vaultImpl{
 		c: c,
 	}, nil

--- a/applications/vault/vault.go
+++ b/applications/vault/vault.go
@@ -48,7 +48,9 @@ func New(ctx context.Context, image string) (Vault, error) {
 	started := false
 	defer func() {
 		if !started {
-			_ = c.Close(ctx)
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			_ = c.Close(cleanupCtx)
 		}
 	}()
 

--- a/container.go
+++ b/container.go
@@ -255,11 +255,25 @@ func (c *container) Run(ctx context.Context) error {
 	return errors.Wrap(err, "error starting container")
 }
 
-// Close cleans up the env (stops & removes the image)
+// Close cleans up the env (stops & removes the container)
 func (c *container) Close(ctx context.Context) error {
+	if c.containerID == "" {
+		return nil
+	}
+
+	// If the provided context is already expired, use a fresh one for cleanup
+	// so a test timeout doesn't prevent container removal.
+	if dl, ok := ctx.Deadline(); ok && time.Until(dl) <= 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(context.Background(), defaultStopTimeout)
+		defer cancel()
+	}
+
 	timeout := defaultStopTimeout
 	if dl, ok := ctx.Deadline(); ok {
-		timeout = time.Until(dl)
+		if remaining := time.Until(dl); remaining > 0 {
+			timeout = remaining
+		}
 	}
 
 	err := c.cli.ContainerStop(ctx, c.containerID, dockerContainer.StopOptions{
@@ -277,7 +291,7 @@ func (c *container) Close(ctx context.Context) error {
 		return err
 	}
 
-	return c.cli.Close()
+	return nil
 }
 
 func (c *container) pullImage(ctx context.Context) error {


### PR DESCRIPTION
…wrappers

All 10 application wrappers (k3s, kafka, memcache, minio, mysql, postgres, rabbitmq, redis, scylladb, vault) now use a deferred cleanup pattern: if the initialization fails at any point after the container starts (AwaitOutput, URL resolution, connection setup, etc.), the container is automatically closed via c.Close(ctx). A boolean flag 'started' prevents cleanup on successful initialization.