### PR TITLE
Close gocql.Session in ScyllaDB Close() to prevent goroutine leak

### DIFF
--- a/applications/scylladb/scylladb.go
+++ b/applications/scylladb/scylladb.go
@@ -181,5 +181,8 @@ func (s *scylladb) DropKeyspace(name string) error {
 }
 
 func (s *scylladb) Close(ctx context.Context) error {
+	if s.session != nil {
+		s.session.Close()
+	}
 	return s.c.Close(ctx)
 }


### PR DESCRIPTION
The gocql.Session opened during initialization was never closed, leaking CQL connections and background goroutines.