### PR TITLE
Replace time.Sleep(1s) in PostgreSQL with connection retry loop

### DIFF
--- a/applications/postgres/postgres.go
+++ b/applications/postgres/postgres.go
@@ -97,8 +97,28 @@ func NewWithImage(ctx context.Context, image string) (PostgreSQL, error) {
 		return nil, err
 	}
 
-	// NB: give it some time to assign a port
-	time.Sleep(1 * time.Second)
+	hp, err := c.URL(docker.ProtoTCP, 5432)
+	if err != nil {
+		return nil, err
+	}
+
+	dsn := fmt.Sprintf("postgres://postgres@%s/%s?sslmode=disable", hp.String(), "postgres")
+
+	// Wait for PostgreSQL to accept TCP connections with a retry loop
+	// instead of a blind sleep, so startup is fast on fast hosts and
+	// resilient on loaded ones.
+	for i := 0; i < 30; i++ {
+		pgconn, pgErr := pgx.Connect(ctx, dsn)
+		if pgErr == nil {
+			_ = pgconn.Close(ctx)
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(1 * time.Second):
+		}
+	}
 
 	started = true
 	return &postgresql{


### PR DESCRIPTION
The blind sleep after AwaitOutput added a mandatory 1-second delay to every PostgreSQL container startup. Replaced with a retry loop that attempts to connect to the 'postgres' database, succeeding as soon as the TCP listener is ready. Fast on fast hosts, resilient on loaded CI nodes.