### PR TITLE
Fix MinIO GetConsoleURL returning S3 port instead of console port

### DIFF
--- a/applications/minio/minio.go
+++ b/applications/minio/minio.go
@@ -89,7 +89,7 @@ func (m *minio) GetEndpointURL() (string, error) {
 }
 
 func (m *minio) GetConsoleURL() (string, error) {
-	hp, err := m.c.URL(docker.ProtoTCP, tcpPortS3)
+	hp, err := m.c.URL(docker.ProtoTCP, tcpPortConsole)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
GetConsoleURL() was using tcpPortS3 (9000) instead of tcpPortConsole (9001), a copy-paste bug from GetEndpointURL().