### PR TITLE
Fix hardcoded HookTypeBeforeClose in hook error messages

### DIFF
--- a/group.go
+++ b/group.go
@@ -53,7 +53,7 @@ func (g *group) Close(ctx context.Context) error {
 
 		err = app.container.Close(ctx)
 		if err != nil {
-			return errors.Wrapf(err, "error closing container %s: `%s`", app.container.Name(), HookTypeBeforeClose)
+			return errors.Wrapf(err, "error closing container `%s`", app.container.Name())
 		}
 
 		err = runHooks(ctx, app, HookTypeAfterClose)
@@ -119,7 +119,7 @@ func runHooks(ctx context.Context, app *Application, ht HookType) error {
 		for _, h := range app.hooks {
 			err := h(ctx, ht, app.container)
 			if err != nil {
-				return errors.Wrapf(err, "error calling `%s` hook for `%s`", HookTypeBeforeClose, app.container.Name())
+				return errors.Wrapf(err, "error calling `%s` hook for `%s`", ht, app.container.Name())
 			}
 		}
 	}


### PR DESCRIPTION
Two bugs in group.go:
1. runHooks() always reported 'before_close' in error messages regardless of which hook type actually failed. Fixed by using the 'ht' parameter instead of the hardcoded constant.
2. Group.Close() error message for container close failures incorrectly referenced HookTypeBeforeClose. Removed the misleading hook type annotation since the error originates from Container.Close().