### PR TITLE
Remove duplicate Close() calls in tests

### DIFF
--- a/container_test.go
+++ b/container_test.go
@@ -45,13 +45,13 @@ func TestContainerRun(t *testing.T) {
 	)
 	r.NoError(err)
 
-	defer func() { _ = c.Close(ctx) }()
-
 	err = c.Ping(ctx)
 	r.NoError(err)
 
 	err = c.Run(ctx)
 	r.NoError(err)
+
+	defer func() { _ = c.Close(ctx) }()
 
 	err = c.AwaitOutput(ctx, NewSubstringMatcher("running GRPC echo server"))
 	r.NoError(err)

--- a/group_test.go
+++ b/group_test.go
@@ -81,6 +81,4 @@ func TestGroup(t *testing.T) {
 	r.NoError(err)
 	r.Equal("test message", resp.GetMessage())
 
-	err = g.Close(ctx)
-	r.NoError(err)
 }


### PR DESCRIPTION
container_test.go: moved the deferred Close() after c.Run() to avoid double-close (one early defer before Run + another defer after Run). group_test.go: removed the explicit g.Close() call — the deferred Close() already handles cleanup even if g.Run() fails.