### PR TITLE
fix(mysql,postgres,scylladb): restrict identifier validation to ASCII…

### DIFF
--- a/applications/mysql/mysql.go
+++ b/applications/mysql/mysql.go
@@ -7,7 +7,6 @@ import (
 	"regexp"
 	"strings"
 	"time"
-	"unicode"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/pkg/errors"
@@ -17,8 +16,9 @@ import (
 
 const maxDBNameLen = 64
 
-// validateDBName validates that name is a safe MySQL unquoted identifier.
-// MySQL unquoted identifiers allow: [a-zA-Z_$] + digits.
+// validateDBName validates that name is a safe MySQL identifier.
+// Only printable ASCII letters, digits, underscore, and dollar sign are
+// allowed to prevent Unicode normalization / homoglyph attacks.
 // See https://dev.mysql.com/doc/en/identifiers.html
 func validateDBName(name string) error {
 	if name == "" {
@@ -28,14 +28,14 @@ func validateDBName(name string) error {
 		return errors.Errorf("database name %q exceeds max length of %d bytes", name, maxDBNameLen)
 	}
 
-	// First character: letter, underscore, or Unicode letter
-	r := []rune(name)
-	if r[0] != '_' && !unicode.IsLetter(r[0]) {
-		return errors.Errorf("invalid database name %q: must start with a letter or underscore", name)
-	}
-
-	for _, c := range r {
-		if c != '_' && c != '$' && !unicode.IsLetter(c) && !unicode.IsDigit(c) {
+	for i, c := range name {
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c >= '0' && c <= '9':
+		case i > 0 && c == '$':
+		case c == '_':
+		default:
 			return errors.Errorf("invalid database name %q: character %q is not allowed", name, c)
 		}
 	}

--- a/applications/postgres/postgres.go
+++ b/applications/postgres/postgres.go
@@ -5,35 +5,38 @@ import (
 	"fmt"
 	"strings"
 	"time"
-	"unicode"
 
 	pgx "github.com/jackc/pgx/v4"
 
+	"github.com/pkg/errors"
 	"github.com/teran/go-docker-testsuite"
 	"github.com/teran/go-docker-testsuite/images"
 )
 
 const maxDBNameLen = 63
 
-// validateDBName validates that name is a safe PostgreSQL unquoted identifier.
-// PostgreSQL allows: letters (including Unicode), underscore, digits, and dollar signs ($).
+// validateDBName validates that name is a safe PostgreSQL identifier.
+// Only printable ASCII letters, digits, and underscore are allowed to
+// prevent Unicode normalization / homoglyph attacks. Note that `$` is
+// NOT valid in PostgreSQL unquoted identifiers (it is only allowed inside
+// dollar-quoted string constants).
 // See https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
 func validateDBName(name string) error {
 	if name == "" {
-		return fmt.Errorf("database name must not be empty")
+		return errors.New("database name must not be empty")
 	}
 	if len(name) > maxDBNameLen {
-		return fmt.Errorf("database name %q exceeds max length of %d bytes", name, maxDBNameLen)
+		return errors.Errorf("database name %q exceeds max length of %d bytes", name, maxDBNameLen)
 	}
 
-	r := []rune(name)
-	if r[0] != '_' && !unicode.IsLetter(r[0]) {
-		return fmt.Errorf("invalid database name %q: must start with a letter or underscore", name)
-	}
-
-	for _, c := range r {
-		if c != '_' && c != '$' && !unicode.IsLetter(c) && !unicode.IsDigit(c) {
-			return fmt.Errorf("invalid database name %q: character %q is not allowed", name, c)
+	for _, c := range name {
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c >= '0' && c <= '9':
+		case c == '_':
+		default:
+			return errors.Errorf("invalid database name %q: character %q is not allowed", name, c)
 		}
 	}
 

--- a/applications/scylladb/scylladb.go
+++ b/applications/scylladb/scylladb.go
@@ -6,9 +6,9 @@ import (
 	"regexp"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/gocql/gocql"
+	"github.com/pkg/errors"
 
 	"github.com/teran/go-docker-testsuite"
 	"github.com/teran/go-docker-testsuite/images"
@@ -17,25 +17,26 @@ import (
 const maxKeyspaceNameLen = 48
 
 // validateKeyspaceName validates that name is a safe CQL identifier.
-// CQL identifiers allow: letters, underscore, and digits.
+// Only printable ASCII letters, digits, and underscore are allowed to
+// prevent Unicode normalization / homoglyph attacks.
 // ScyllaDB keyspace names are limited to 48 characters.
 // See https://docs.scylladb.com/stable/cql/ddl.html
 func validateKeyspaceName(name string) error {
 	if name == "" {
-		return fmt.Errorf("keyspace name must not be empty")
+		return errors.New("keyspace name must not be empty")
 	}
 	if len(name) > maxKeyspaceNameLen {
-		return fmt.Errorf("keyspace name %q exceeds max length of %d characters", name, maxKeyspaceNameLen)
+		return errors.Errorf("keyspace name %q exceeds max length of %d characters", name, maxKeyspaceNameLen)
 	}
 
-	r := []rune(name)
-	if r[0] != '_' && !unicode.IsLetter(r[0]) {
-		return fmt.Errorf("invalid keyspace name %q: must start with a letter or underscore", name)
-	}
-
-	for _, c := range r {
-		if c != '_' && !unicode.IsLetter(c) && !unicode.IsDigit(c) {
-			return fmt.Errorf("invalid keyspace name %q: character %q is not allowed", name, c)
+	for _, c := range name {
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c >= '0' && c <= '9':
+		case c == '_':
+		default:
+			return errors.Errorf("invalid keyspace name %q: character %q is not allowed", name, c)
 		}
 	}
 


### PR DESCRIPTION
…-only chars

Replace unicode.IsLetter/IsDigit with explicit ASCII range checks in DDL identifier validation to prevent Unicode normalization and homoglyph attacks (e.g. Cyrillic 'а' vs Latin 'a').

MySQL: allows [a-zA-Z0-9_$], $ only after first char PostgreSQL: allows [a-zA-Z0-9_] (removed $ which is invalid in
            unquoted PG identifiers)
ScyllaDB: allows [a-zA-Z0-9_]

Also switch postgres and scylladb from fmt.Errorf to errors.Errorf for consistency with project conventions.